### PR TITLE
[ENH] Updated qgram tokenizer to pad the input strings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ results/
 
 # Project specific
 cythonize.dat
+
+garage/
+cover/

--- a/py_stringmatching/tests/test_tokenizers.py
+++ b/py_stringmatching/tests/test_tokenizers.py
@@ -115,6 +115,35 @@ class QgramTokenizerTestCases(unittest.TestCase):
         self.assertEqual(tok.tokenize('database'),
                          ['##d', '#da', 'dat', 'ata', 'tab', 'aba', 'bas', 'ase', 'se$', 'e$$'])
 
+    def test_set_padding(self):
+        tok = QgramTokenizer()
+        self.assertEqual(tok.get_padding(), True)
+        self.assertEqual(tok.tokenize('database'),
+                         ['#d', 'da', 'at', 'ta', 'ab', 'ba', 'as', 'se', 'e$'])
+        tok.set_padding(False)
+        self.assertEqual(tok.get_padding(), False)
+        self.assertEqual(tok.tokenize('database'),
+                         ['da', 'at', 'ta', 'ab', 'ba', 'as', 'se'])
+
+    def test_set_prefix_pad(self):
+        tok = QgramTokenizer()
+        self.assertEqual(tok.get_prefix_pad(), '#')
+        self.assertEqual(tok.tokenize('database'),
+                         ['#d', 'da', 'at', 'ta', 'ab', 'ba', 'as', 'se', 'e$'])
+        tok.set_prefix_pad('^')
+        self.assertEqual(tok.get_prefix_pad(), '^')
+        self.assertEqual(tok.tokenize('database'),
+                         ['^d', 'da', 'at', 'ta', 'ab', 'ba', 'as', 'se', 'e$'])
+
+    def test_set_suffix_pad(self):
+        tok = QgramTokenizer()
+        self.assertEqual(tok.get_suffix_pad(), '$')
+        self.assertEqual(tok.tokenize('database'),
+                         ['#d', 'da', 'at', 'ta', 'ab', 'ba', 'as', 'se', 'e$'])
+        tok.set_suffix_pad('!')
+        self.assertEqual(tok.get_suffix_pad(), '!')
+        self.assertEqual(tok.tokenize('database'),
+                         ['#d', 'da', 'at', 'ta', 'ab', 'ba', 'as', 'se', 'e!'])
 
     @raises(TypeError)
     def test_qgrams_none(self):
@@ -132,6 +161,51 @@ class QgramTokenizerTestCases(unittest.TestCase):
     def test_set_qval_invalid(self):
         qg_tok = QgramTokenizer()
         qg_tok.set_qval(0)
+
+    @raises(AssertionError)
+    def test_padding_invalid(self):
+        _ = QgramTokenizer(padding=10)
+
+    @raises(AssertionError)
+    def test_set_padding_invalid(self):
+        qg = QgramTokenizer()
+        qg.set_padding(10)
+
+    @raises(AssertionError)
+    def test_prefixpad_invalid1(self):
+        _ = QgramTokenizer(prefix_pad=10)
+
+    @raises(AssertionError)
+    def test_prefixpad_invalid2(self):
+        _ = QgramTokenizer(prefix_pad="###")
+
+    @raises(AssertionError)
+    def test_set_prefix_pad_invalid1(self):
+        qg = QgramTokenizer()
+        qg.set_prefix_pad(10)
+
+    @raises(AssertionError)
+    def test_set_prefix_pad_invalid2(self):
+        qg = QgramTokenizer()
+        qg.set_prefix_pad('###')
+
+    @raises(AssertionError)
+    def test_suffixpad_invalid1(self):
+        _ = QgramTokenizer(suffix_pad=10)
+
+    @raises(AssertionError)
+    def test_suffixpad_invalid2(self):
+        _ = QgramTokenizer(suffix_pad="###")
+
+    @raises(AssertionError)
+    def test_set_suffix_pad_invalid1(self):
+        qg = QgramTokenizer()
+        qg.set_suffix_pad(10)
+
+    @raises(AssertionError)
+    def test_set_suffix_pad_invalid2(self):
+        qg = QgramTokenizer()
+        qg.set_suffix_pad('###')
 
 
 class DelimiterTokenizerTestCases(unittest.TestCase):

--- a/py_stringmatching/tokenizer/qgram_tokenizer.py
+++ b/py_stringmatching/tokenizer/qgram_tokenizer.py
@@ -186,6 +186,7 @@ class QgramTokenizer(DefinitionTokenizer):
         if not len(prefix_pad) == 1:
             raise AssertionError("prefix_pad should have length equal to 1")
         self.prefix_pad = prefix_pad
+        return True
 
     def get_suffix_pad(self):
         """
@@ -196,7 +197,7 @@ class QgramTokenizer(DefinitionTokenizer):
             The suffix pad string.
 
         """
-        return self.prefix_pad
+        return self.suffix_pad
 
     def set_suffix_pad(self, suffix_pad):
         """
@@ -220,3 +221,4 @@ class QgramTokenizer(DefinitionTokenizer):
         if not len(suffix_pad) == 1:
             raise AssertionError("suffix_pad should have length equal to 1")
         self.suffix_pad = suffix_pad
+        return True

--- a/py_stringmatching/tokenizer/qgram_tokenizer.py
+++ b/py_stringmatching/tokenizer/qgram_tokenizer.py
@@ -1,5 +1,7 @@
-from py_stringmatching import utils
+from six import string_types
 from six.moves import xrange
+
+from py_stringmatching import utils
 from py_stringmatching.tokenizer.definition_tokenizer import DefinitionTokenizer
 
 
@@ -18,11 +20,30 @@ class QgramTokenizer(DefinitionTokenizer):
         qval (int): An attribute to store the q value.
         return_set (boolean): An attribute to store the flag return_set.
     """
-    
-    def __init__(self, qval=2, return_set=False):
+
+    def __init__(self, qval=2,
+                 padding=True, prefix_pad='#', suffix_pad='$',
+                 return_set=False):
         if qval < 1:
-            raise AssertionError("qval cannot be less than 1") 
+            raise AssertionError("qval cannot be less than 1")
         self.qval = qval
+
+        if not type(padding) == type(True):
+            raise AssertionError('padding is expected to be boolean type')
+        self.padding = padding
+
+        if not isinstance(prefix_pad, string_types):
+            raise AssertionError('prefix_pad is expected to be of type string')
+        if not isinstance(suffix_pad, string_types):
+            raise AssertionError('suffix_pad is expected to be of type string')
+        if not len(prefix_pad) == 1:
+            raise AssertionError("prefix_pad should have length equal to 1")
+        if not len(suffix_pad) == 1:
+            raise AssertionError("suffix_pad should have length equal to 1")
+
+        self.prefix_pad = prefix_pad
+        self.suffix_pad = suffix_pad
+
         super(QgramTokenizer, self).__init__(return_set)
 
     def tokenize(self, input_string):
@@ -40,30 +61,41 @@ class QgramTokenizer(DefinitionTokenizer):
         Examples:
             >>> qg2_tok = QgramTokenizer()
             >>> qg2_tok.tokenize('database')
-            ['da','at','ta','ab','ba','as','se']
+            ['#d', 'da', 'at', 'ta', 'ab', 'ba', 'as', 'se', 'e$']
             >>> qg2_tok.tokenize('a')
-            []
-            >>> qg3_tok = QgramTokenizer(3) 
+            ['#a', 'a$']
+            >>> qg3_tok = QgramTokenizer(qval=3)
             >>> qg3_tok.tokenize('database')
-            ['dat', 'ata', 'tab', 'aba', 'bas', 'ase']
+            ['##d', '#da', 'dat', 'ata', 'tab', 'aba', 'bas', 'ase', 'se$', 'e$$']
+            >>> qg3_nopad = QgramTokenizer(padding=False)
+            >>> qg3_nopad.tokenize('database')
+            ['da', 'at', 'ta', 'ab', 'ba', 'as', 'se']
+            >>> qg3_diffpads = QgramTokenizer(prefix_pad='^', suffix_pad='!')
+            >>> qg3_diffpads.tokenize('database')
+            ['^d', 'da', 'at', 'ta', 'ab', 'ba', 'as', 'se', 'e!']
                       
-            As these examples show, the current qgram tokenizer does not consider the case of appending #s at the 
-            start and the end of the input string. This is left for future work. 
         """
         utils.tok_check_for_none(input_string)
         utils.tok_check_for_string_input(input_string)
 
         qgram_list = []
 
+        # If the padding flag is set to true, add q-1 "prefix_pad" characters
+        # in front of the input string and  add q-1 "suffix_pad" characters at
+        # the end of the input string.
+        if self.padding:
+            input_string = (self.prefix_pad * (self.qval - 1)) + input_string \
+                           + (self.suffix_pad * (self.qval - 1))
+
         if len(input_string) < self.qval:
             return qgram_list
 
-        qgram_list = [input_string[i:i + self.qval] for i in 
-                          xrange(len(input_string) - (self.qval - 1))]
+        qgram_list = [input_string[i:i + self.qval] for i in
+                      xrange(len(input_string) - (self.qval - 1))]
         qgram_list = list(filter(None, qgram_list))
 
         if self.return_set:
-            return utils.convert_bag_to_set(qgram_list)            
+            return utils.convert_bag_to_set(qgram_list)
 
         return qgram_list
 
@@ -88,3 +120,103 @@ class QgramTokenizer(DefinitionTokenizer):
             raise AssertionError("qval cannot be less than 1")
         self.qval = qval
         return True
+
+    def get_padding(self):
+        """
+        Gets the value of the padding flag. This flag determines whether the
+        padding should be done for the input strings or not.
+
+        Returns:
+            The boolean value of the padding flag.
+
+        """
+        return self.padding
+
+    def set_padding(self, padding):
+        """
+        Sets the value of the padding flag.
+
+        Args:
+            padding (boolean): Flag to indicate whether padding should be
+                done or not.
+
+        Returns:
+            The boolean value of True is returned if the update was
+            successful.
+
+        Raises:
+            AssertionError: If the padding is not of type boolean
+
+        """
+        if not type(padding) == type(True):
+            raise AssertionError('padding is expected to be boolean type')
+        self.padding = padding
+        return True
+
+    def get_prefix_pad(self):
+        """
+        Gets the value of the prefix pad.
+
+
+        Returns:
+            The prefix pad string.
+
+        """
+        return self.prefix_pad
+
+    def set_prefix_pad(self, prefix_pad):
+        """
+        Sets the value of the prefix pad string.
+
+        Args:
+            prefix_pad (str): String that should be prepended to the
+            input string before tokenization.
+
+        Returns:
+            The boolean value of True is returned if the update was
+            successful.
+
+        Raises:
+            AssertionError: If the prefix_pad is not of type string.
+            AssertionError: If the length of prefix_pad is not one.
+
+        """
+        if not isinstance(prefix_pad, string_types):
+            raise AssertionError('prefix_pad is expected to be of type string')
+        if not len(prefix_pad) == 1:
+            raise AssertionError("prefix_pad should have length equal to 1")
+        self.prefix_pad = prefix_pad
+
+    def get_suffix_pad(self):
+        """
+        Gets the value of the suffix pad.
+
+
+        Returns:
+            The suffix pad string.
+
+        """
+        return self.prefix_pad
+
+    def set_suffix_pad(self, suffix_pad):
+        """
+        Sets the value of the prefix pad string.
+
+        Args:
+            suffix_pad (str): String that should be appended to the
+            input string before tokenization.
+
+        Returns:
+            The boolean value of True is returned if the update was
+            successful.
+
+        Raises:
+            AssertionError: If the suffix_pad is not of type string.
+            AssertionError: If the length of suffix_pad is not one.
+
+        """
+        if not isinstance(suffix_pad, string_types):
+            raise AssertionError('suffix_pad is expected to be of type string')
+        if not len(suffix_pad) == 1:
+            raise AssertionError("suffix_pad should have length equal to 1")
+        self.suffix_pad = suffix_pad

--- a/py_stringmatching/tokenizer/qgram_tokenizer.py
+++ b/py_stringmatching/tokenizer/qgram_tokenizer.py
@@ -15,10 +15,23 @@ class QgramTokenizer(DefinitionTokenizer):
         qval (int): A value for q, that is, the qgram's length (defaults to 2).
         return_set (boolean): A flag to indicate whether to return a set of
                               tokens or a bag of tokens (defaults to False).
-                              
+        padding (boolean): A flag to indicate whether padding should be done
+                            to the input string (defaults to True).
+        prefix_pad (str): A string (of length 1) that should be used to
+                            prepend the input string, if padding was set to
+                            True (defaults to '#').
+        suffix_pad (str): A string (of length 1) that should be used to
+                            append the input string, if padding was set to
+                            True (defaults to '$').
+
+
     Attributes:
         qval (int): An attribute to store the q value.
         return_set (boolean): An attribute to store the flag return_set.
+        padding (boolean): An attribute to store the padding flag.
+        prefix_pad (str): An attribute to store the prefix string that should be used for padding.
+        suffix_pad (str): An attribute to store the suffix string that should
+                        be used for padding.
     """
 
     def __init__(self, qval=2,


### PR DESCRIPTION
* Updated the qgram tokenizer to pad the input strings.
* Specifically, added three parameters to qgram tokenizer constructor: padding, prefix_pad, suffix_pad. These parameters control padding and what characters that should be used for padding.