### PR TITLE
setup.py: Lazy evaluate if pip is needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,13 @@ try:
 except ImportError:
     PIP_INSTALLED = False
 
-if not PIP_INSTALLED:
-    raise ImportError('pip is not installed.')
-
 def install_and_import(package):
     import importlib
     try:
         importlib.import_module(package)
     except ImportError:
+        if not PIP_INSTALLED:
+            raise ImportError('pip is not installed.')
         pip.main(['install', package])
     finally:
         globals()[package] = importlib.import_module(package)


### PR DESCRIPTION
If pip is not needed (all required modules are alreay installed) then do
not throw an error if pip is not installed.

This makes it difficult to make packages like conda packages.