### PR TITLE
Fix Monge-Elkan example

### DIFF
--- a/py_stringmatching/similarity_measure/monge_elkan.py
+++ b/py_stringmatching/similarity_measure/monge_elkan.py
@@ -43,7 +43,7 @@ class MongeElkan(HybridSimilarityMeasure):
             >>> me.get_raw_score(['Niall'], ['Nigel'])
             0.7866666666666667
             >>> me.get_raw_score(['Comput.', 'Sci.', 'and', 'Eng.', 'Dept.,', 'University', 'of', 'California,', 'San', 'Diego'], ['Department', 'of', 'Computer', 'Science,', 'Univ.', 'Calif.,', 'San', 'Diego'])
-            0.8677218614718616
+            0.8364448130130768
             >>> me.get_raw_score([''], ['a'])
             0.0
             >>> me = MongeElkan(sim_func=NeedlemanWunsch().get_raw_score)


### PR DESCRIPTION
The Monge-Elkan similarity of "Comput. Sci. and Eng. Dept., University of California, San Diego" and "Department of Computer Science, Univ. Calif., San Diego" is wrong in the example. The correct value is 0.8364448130130768.

    Python 3.7.7 (default, Mar 10 2020, 15:43:33) 
    [Clang 11.0.0 (clang-1100.0.33.17)] on darwin
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import py_stringmatching as sm
    >>> me = sm.MongeElkan()
    >>> me.get_raw_score(['Comput.', 'Sci.', 'and', 'Eng.', 'Dept.,', 'University', 'of', 'California,', 'San', 'Diego'], ['Department', 'of', 'Computer', 'Science,', 'Univ.', 'Calif.,', 'San', 'Diego'])
    0.8364448130130768