### PR TITLE
Drop support for Python 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ matrix:
     python: 2.7
     env: PYTHON_VERSION=2.7
   - os: linux
-    python: 3.4
-    env: PYTHON_VERSION=3.4
-  - os: linux
     python: 3.5
     env: PYTHON_VERSION=3.5
   - os: linux                                                                   
@@ -19,10 +16,6 @@ matrix:
     language: generic
     env:
     - PYTHON_VERSION=2.7
-  - os: osx
-    language: generic
-    env:
-    - PYTHON_VERSION=3.4
   - os: osx
     language: generic
     env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@ environment:
   matrix:
     - python : 27
     - python : 27-x64
-    - python : 34
-    - python : 34-x64
     - python : 35
     - python : 35-x64
     - python : 36                                                               


### PR DESCRIPTION
Python 3.4 is deprecated, and conda has dropped it from its normal channels; see this [post](https://stackoverflow.com/questions/57449169/how-to-install-deprecated-unsupported-python-3-4-on-conda-environment) for a summary.

Conda threw errors in CI trying to find it, and neither py_stringsimjoin nor py_entitymatching still support Python 3.4. This PR removes it from Travis and Appveyor CI scripts.