### PR TITLE
Add CI for Python 3.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - conda create --yes -n py_stringmatching_test_env python=$PYTHON_VERSION
   - source activate py_stringmatching_test_env
   - python --version
-  - pip install numpy six nose Cython coveralls
+  - pip install numpy six nose Cython>=0.29.23 coveralls
   - python setup.py build_ext --inplace
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
   - os: linux
     python: 3.8
     env: PYTHON_VERSION=3.8
+  - os: linux
+    python: 3.9
+    env: PYTHON_VERSION=3.9
 
   - os: osx
     language: generic
@@ -22,6 +25,10 @@ matrix:
     language: generic
     env:
     - PYTHON_VERSION=3.8
+  - os: osx
+    language: generic
+    env:
+    - PYTHON_VERSION=3.9
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == linux ]; then MINICONDAVERSION="Linux"; else MINICONDAVERSION="MacOSX"; fi

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Important links
 Dependencies
 ============
 
-py_stringmatching has been tested on Python 2.7, 3.5, 3.6, 3.7, and 3.8.
+py_stringmatching has been tested on Python 3.6, 3.7, 3.8, and 3.9.
 
 The required dependencies to build the package are NumPy 1.7.0 or higher,
 Six, and a C or C++ compiler. For the development version, you will also need Cython.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - python -m pip install --upgrade pip
 
   # Install the build and runtime dependencies of the project.
-  - pip install setuptools numpy six nose cython wheel
+  - pip install setuptools numpy six nose cython>=0.29.23 wheel
 
   # Build the project
   - python setup.py build_ext --inplace

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
     - python : 37-x64
     - python : 38
     - python : 38-x64
+    - python : 39
+    - python : 39-x64
 
 install:
 

--- a/docs/Contributing.rst
+++ b/docs/Contributing.rst
@@ -203,17 +203,9 @@ At this point you can easily do an *in-place* install, as detailed in the next s
 Creating a Windows development environment
 ------------------------------------------
 
-To build on Windows, you need to have compilers installed to build the extensions. You will need to install the appropriate Visual Studio compilers, VS 2008 for Python 2.7, VS 2010 for 3.4, and VS 2015 for Python 3.5.
+To build on Windows, you need to have compilers installed to build the extensions. You will need to install the appropriate Visual Studio compilers; the most recent is VS 2019.
 
-For Python 2.7, you can install the ``mingw`` compiler which will work equivalently to VS 2008::
-
-      conda install -n py_stringmatching_dev libpython
-
-or use the `Microsoft Visual Studio VC++ compiler for Python <https://www.microsoft.com/en-us/download/details.aspx?id=44266>`__. Note that you have to check the ``x64`` box to install the ``x64`` extension building capability as this is not installed by default.
-
-For Python 3.4, you can download and install the `Windows 7.1 SDK <https://www.microsoft.com/en-us/download/details.aspx?id=8279>`__. Read the references below as there may be various gotchas during the installation.
-
-For Python 3.5, you can download and install the `Visual Studio 2015 Community Edition <https://www.visualstudio.com/en-us/downloads/visual-studio-2015-downloads-vs.aspx>`__.
+To obtain VS 2019, you can download and install the `Visual Studio 2019 Community Edition <https://visualstudio.microsoft.com/downloads/>`__.
 
 Here are some references and blogs:
 

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -49,3 +49,10 @@ Step 2: Unzip the package and execute the following command from the package roo
 
     For more information see the StackOverflow `link
     <http://stackoverflow.com/questions/14179941/how-to-install-python-packages-without-root-privileges>`_.
+
+.. note::
+
+    Building C files from source requires Cython version 0.29.23 or higher::
+    
+        pip install Cython>=0.29.23
+

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -4,12 +4,8 @@ Installation
  
 Requirements
 ------------
-    * Python 2.7, 3.5, 3.6, 3.7, or 3.8
-    * C or C++ compiler (parts of the package are in Cython for efficiency reasons, and you need C or C++ compiler to compile these parts) 
-
-.. note::
-
-     py_stringmatching 0.4.2 will be the last version to support Python 2 and Python 3.5.
+    * Python 3.6, 3.7, 3.8, or 3.9
+    * C or C++ compiler (parts of the package are in Cython for efficiency reasons, and you need C or C++ compiler to compile these parts)
 
 Platforms
 ------------
@@ -17,7 +13,7 @@ py_stringmatching has been tested on Linux (Ubuntu with Kernel Version 3.13.0-40
 
 Dependencies
 ------------
-    * numpy 1.7.0 or higher; if using Python 2, numpy less than 1.17; if using Python 3.5, numpy less than 1.19
+    * numpy 1.7.0 or higher
     * six
 
 .. note::

--- a/docs/WhatIsNew.rst
+++ b/docs/WhatIsNew.rst
@@ -1,8 +1,6 @@
 What is New? 
 ============
 
-Compared to Version 0.4.1, the following items are new:
+Compared to Version 0.4.2, the following items are new:
 
-  * Bug fix: Made PartialRatio importable from py_stringmatching.
-  * Dropped support for Python 3.4.
-  * This is the last version of py_stringmatching that will support Python 2 and Python 3.5.
+  * Dropped support for Python 3.5, added support for Python 3.9.

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
             'Topic :: Scientific/Engineering',
             'Topic :: Utilities',
             'Topic :: Software Development :: Libraries',


### PR DESCRIPTION
This PR adds Python 3.9 to the set of Python versions that `py-stringmatching` is tested against. It updates the documentation accordingly, adding notes for building C files from source to address #69.