### PR TITLE
Replace aliases removed from numpy 1.24 (#80)

### DIFF
--- a/py_stringmatching/similarity_measure/cython/cython_levenshtein.pyx
+++ b/py_stringmatching/similarity_measure/cython/cython_levenshtein.pyx
@@ -8,7 +8,7 @@ from py_stringmatching.similarity_measure.cython.cython_utils import int_min_thr
 from numpy import int32
 from numpy cimport int32_t
 
-DTYPE = np.int
+DTYPE = int
 ctypedef np.int_t DTYPE_t
 
 @cython.boundscheck(False)

--- a/py_stringmatching/similarity_measure/cython/cython_needleman_wunsch.pyx
+++ b/py_stringmatching/similarity_measure/cython/cython_needleman_wunsch.pyx
@@ -20,7 +20,7 @@ def needleman_wunsch(unicode string1, unicode string2, float gap_cost,
     cdef double match = 0.0, delete = 0.0, insert = 0.0
     cdef double sim_func_score = 0.0
     cdef int len_s1 = len(string1), len_s2 = len(string2)
-    cdef double[:,:] dist_mat = np.zeros((len(string1) + 1, len(string2) + 1), dtype=np.float)
+    cdef double[:,:] dist_mat = np.zeros((len(string1) + 1, len(string2) + 1), dtype=float)
 
     # DP initialization
     for i from 0 <= i < (len_s1 + 1):

--- a/py_stringmatching/similarity_measure/cython/cython_smith_waterman.pyx
+++ b/py_stringmatching/similarity_measure/cython/cython_smith_waterman.pyx
@@ -13,7 +13,7 @@ def smith_waterman(unicode string1, unicode string2, float gap_cost, \
     cdef double match = 0.0, delete = 0.0, insert = 0.0
     cdef double sim_score = 0.0, max_value = 0.0
     cdef int len_s1 = len(string1), len_s2 = len(string2)
-    cdef double[:,:] dist_mat = np.zeros((len(string1) + 1, len(string2) + 1), dtype=np.float)
+    cdef double[:,:] dist_mat = np.zeros((len(string1) + 1, len(string2) + 1), dtype=float)
 
 
     # Smith Waterman DP calculations

--- a/py_stringmatching/similarity_measure/editex.py
+++ b/py_stringmatching/similarity_measure/editex.py
@@ -91,7 +91,7 @@ class Editex(SequenceSimilarityMeasure):
         if len(string2) == 0:
             return len(string1) * self.mismatch_cost
 
-        d_mat = np.zeros((len(string1) + 1, len(string2) + 1), dtype=np.int)
+        d_mat = np.zeros((len(string1) + 1, len(string2) + 1), dtype=int)
         len1 = len(string1)
         len2 = len(string2)
         string1 = ' ' + string1


### PR DESCRIPTION
`numpy` v1.23 and before still contained `numpy.int` and `numpy.float`,
which were aliases for the builtin `int` and `float` objects.  `numpy`
v1.24.0 removed these aliases, and this commit simply switches to the
builtins.

Fixes #80.
