### PR TITLE
Replace underscore with hyphen in project name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
         LONG_DESCRIPTION = f.read()
 
     setuptools.setup(
-        name='py_stringmatching',
+        name='py-stringmatching',
         version='0.4.3',
         description='Python library for string matching.',
         long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
...as passed to setuptools.setup.

The hyphenated version is the canonical name on PyPI.  Some versions of
some tools will automatically replace the underscore, but this is
unreliable and can cause problems when, for example, one creates a
library that depends on `py-stringmatching`, but `pip` installs it as
`py_stringmatching`, and then unneeded packages are removed from the
environment (causing `py_stringmatching` to be removed).
